### PR TITLE
Update to v1.16.0-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 A peer-to-peer VPN system
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://www.zerotier.com/)
-[![Version: 1.16.0~ynh1](https://img.shields.io/badge/Version-1.16.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/zerotier/)
+[![Version: 1.16.0-2~ynh1](https://img.shields.io/badge/Version-1.16.0--2~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/zerotier/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/zerotier"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "ZeroTier"
 description.en = "A peer-to-peer VPN system"
 description.fr = "Un VPN pair-à-pair"
 
-version = "1.16.0~ynh1"
+version = "1.16.0-2~ynh1"
 
 maintainers = ["tituspijean"]
 


### PR DESCRIPTION
v1.16.0 cannot be installed anymore because the initial release has been removed upstream.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
v1.16.0 initial source has been removed. :/